### PR TITLE
Update android build tools to 23.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   tar xf android-sdk_r24.4.1-linux.tgz -C /opt && \
   rm android-sdk_r24.4.1-linux.tgz && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter tools && \
-  echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter platform-tools,build-tools-23.0.2,android-23 && \
+  echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter platform-tools,build-tools-23.0.3,android-23 && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository
 
 # Install Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   tar xf android-sdk_r24.4.1-linux.tgz -C /opt && \
   rm android-sdk_r24.4.1-linux.tgz && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter tools && \
-  echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter platform-tools,build-tools-23.0.3,android-23 && \
+  echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter platform-tools,build-tools-23.0.2,build-tools-23.0.3,android-23 && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository
 
 # Install Gradle

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - OpenJDK 7
 - OpenJDK 6
 - Android SDK 24.4.1
-- Build tools 23.0.3
+- Build tools 23.0.2, 23.0.3
 - Android API 23
 - Google Play Services
 - Android Support Libraries

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@
 - OpenJDK 7
 - OpenJDK 6
 - Android SDK 24.4.1
-- Build tools 23.0.2
+- Build tools 23.0.3
 - Android API 23
 - Google Play Services
 - Android Support Libraries
 - Gradle 2.10
-
-


### PR DESCRIPTION
Updated Android SDK Build Tools to 23.0.3(current latest) ,issued in March 2016.
