### PR TITLE
update build tools to latest versions thant have not been installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN \
   rm android-sdk_r24.4.1-linux.tgz && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter tools && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter platform-tools && \
+  echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter build-tools-25.0.2 && \
+  echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter build-tools-25.0.1 && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter build-tools-25.0.0 && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter build-tools-24.0.2 && \
   echo y | /opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter build-tools-24.0.0 && \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - OpenJDK 7
 - OpenJDK 6
 - Android SDK 24.4.1
-- Build tools 23.0.2, 23.0.3, 24.0.0, 24.0.2, 25.0.0
+- Build tools 23.0.2, 23.0.3, 24.0.0, 24.0.2, 25.0.0, 25.0.1, 25.0.2
 - Android API 23, 24, 25
 - Google Play Services
 - Android Support Libraries


### PR DESCRIPTION
We encountered error below in wercker.  it may be necessary to install  latest build tools version.
c.f. https://developer.android.com/studio/releases/build-tools.html

```

File /root/.android/repositories.cfg could not be loaded.
Checking the license for package Android SDK Build-Tools 25.0.2 in /opt/android-sdk-linux/licenses
Warning: License for package Android SDK Build-Tools 25.0.2 not accepted.

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> You have not accepted the license agreements of the following SDK components:
  [Android SDK Build-Tools 25.0.2].
  Before building your project, you need to accept the license agreements and complete the installation of the missing components using the Android Studio SDK Manager.
  Alternatively, to learn how to transfer the license agreements from one workstation to another, go to http://d.android.com/r/studio-ui/export-licenses.html
```